### PR TITLE
Switch to using pointers everywhere with arbitrary_self_types

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=tests
-      - label!=work-in-progress
+      - "label!=work in progress"
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
@@ -17,7 +17,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=tests
-      - label!=work-in-progress
+      - "label!=work in progress"
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
@@ -36,10 +36,10 @@ pull_request_rules:
       - "title~=^WIP: .*"
     actions:
       label:
-        add: ["work-in-progress"]
+        add: ["work in progress"]
   - name: auto remove wip label
     conditions:
       - "-title~=^WIP: .*"
     actions:
       label:
-        remove: ["work-in-progress"]
+        remove: ["work in progress"]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge
@@ -21,7 +20,6 @@ pull_request_rules:
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatype"
-version = "0.1.2"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","rust-patterns"]
@@ -10,7 +10,7 @@ Helper methods to determine whether a type is `TraitObject`, `Slice` or `Concret
 """
 repository = "https://github.com/alecmocatta/metatype"
 homepage = "https://github.com/alecmocatta/metatype"
-documentation = "https://docs.rs/metatype/0.1.2"
+documentation = "https://docs.rs/metatype/0.2.0"
 readme = "README.md"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,23 @@ assert_eq!(any::Any::METATYPE, MetaType::TraitObject);
 assert_eq!(<[u8]>::METATYPE, MetaType::Slice);
 
 let a: Box<usize> = Box::new(123);
-assert_eq!((&*a).meta_type(), MetaType::Concrete);
-let a: Box<any::Any> = a;
-assert_eq!((&*a).meta_type(), MetaType::TraitObject);
+assert_eq!(Type::meta_type(&*a), MetaType::Concrete);
+let a: Box<dyn any::Any> = a;
+assert_eq!(Type::meta_type(&*a), MetaType::TraitObject);
 
 let a = [123,456];
-assert_eq!(a.meta_type(), MetaType::Concrete);
+assert_eq!(Type::meta_type(&a), MetaType::Concrete);
 let a: &[i32] = &a;
-assert_eq!(a.meta_type(), MetaType::Slice);
+assert_eq!(Type::meta_type(a), MetaType::Slice);
 
-let a: Box<any::Any> = Box::new(123);
-// https://github.com/rust-lang/rust/issues/50318
-// let meta: TraitObject = (&*a).meta();
-// println!("vtable: {:?}", meta.vtable);
+let a: Box<dyn any::Any> = Box::new(123);
+let meta: TraitObject = type_coerce(Type::meta(&*a));
+println!("vtable: {:?}", meta.vtable);
 ```
 
 ## Note
 
-This currently requires Rust nightly for the `raw` and `specialization` features.
+This currently requires Rust nightly for the `raw`, `specialization` and `arbitrary_self_types` features.
 
 ## License
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/metatype.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/metatype/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/metatype/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/metatype/0.1.2)
+[Docs](https://docs.rs/metatype/0.2.0)
 
 Helper methods to determine whether a type is `TraitObject`, `Slice` or `Concrete`, and work with them respectively.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-07-19
+      rust_lint_toolchain: nightly-2019-10-17
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ resources:
 jobs:
 - template: rust.yml@templates
   parameters:
+    endpoint: alecmocatta
     default:
       rust_toolchain: stable nightly
       rust_lint_toolchain: nightly-2019-07-19

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,14 @@
 	unused_results,
 	clippy::pedantic
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
-#![allow(clippy::not_unsafe_ptr_arg_deref, clippy::use_self)]
+#![allow(
+	clippy::must_use_candidate,
+	clippy::not_unsafe_ptr_arg_deref,
+	clippy::use_self
+)]
 
 use std::{
-	any::type_name, marker::PhantomData, mem::{align_of, align_of_val, forget, size_of, size_of_val, transmute_copy}, ptr::{slice_from_raw_parts_mut, NonNull}, raw
+	any::{type_name, TypeId}, hash::{Hash, Hasher}, marker::PhantomData, mem::{align_of, align_of_val, forget, size_of, size_of_val, transmute_copy}, ptr::{slice_from_raw_parts_mut, NonNull}, raw
 };
 
 /// Implemented on all types, it provides helper methods to determine whether a type is `TraitObject`, `Slice` or `Concrete`, and work with them respectively.
@@ -279,6 +283,16 @@ pub fn try_type_coerce<A, B>(a: A) -> Option<B> {
 	}
 
 	Foo::<A, B>(a, PhantomData).eq()
+}
+
+/// Gets an identifier which is globally unique to the specified type. This
+/// function will return the same value for a type regardless of whichever crate
+/// it is invoked in.
+pub fn type_id<T: ?Sized + 'static>() -> u64 {
+	let type_id = TypeId::of::<T>();
+	let mut hasher = std::collections::hash_map::DefaultHasher::new();
+	type_id.hash(&mut hasher);
+	hasher.finish()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! This currently requires Rust nightly for the `raw`, `specialization` and
 //! `arbitrary_self_types` features.
 
-#![doc(html_root_url = "https://docs.rs/metatype/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/metatype/0.2.0")]
 #![feature(arbitrary_self_types)]
 #![feature(raw)]
 #![feature(slice_from_raw_parts)]


### PR DESCRIPTION
This PR removes `uninitialized_box` as well as uninitialized fat references, replacing them with fat pointers thanks to the `arbitrary_self_types` feature.

Two instances of uninitialized references remains. One is blocked on https://github.com/rust-lang/rfcs/issues/2017. It could be removed if we're okay with `<dyn Trait as Type>::dangling()` returning pointers with a fixed alignment (say 64 or 4096?). The other is blocked on getting slice length from a pointer; this could be removed if we're okay with assuming the layout and getting it ourselves.